### PR TITLE
BUG: allow more platforms, add unique function name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: erlang
+language: generic
 
 matrix:
   include:

--- a/gfortran_utils.sh
+++ b/gfortran_utils.sh
@@ -11,7 +11,7 @@ function get_distutils_platform {
     # Modify fat architecture tags on macOS to reflect compiled architecture
     local plat=$1
     case $plat in
-        i686|x86_64|intel) ;;
+        i686|x86_64|intel|aarch64|s390x|ppc64le) ;;
         *) echo Did not recognize plat $plat; return 1 ;;
     esac
     local uname=${2:-$(uname)}
@@ -21,6 +21,32 @@ function get_distutils_platform {
             return 1
         fi
         echo "manylinux1_$plat"
+        return
+    fi
+    # macOS 32-bit arch is i386
+    [ "$plat" == "i686" ] && plat="i386"
+    local target=$(echo $MACOSX_DEPLOYMENT_TARGET | tr .- _)
+    echo "macosx_${target}_${plat}"
+}
+
+function get_distutils_platform_ex {
+    # Report platform as in form of distutils get_platform.
+    # This is like the platform tag that pip will use.
+    # Modify fat architecture tags on macOS to reflect compiled architecture
+    # For non-darwin, report manylinux version
+    local plat=$1
+    local MB_ML_VER=${MB_ML_VER:-1}
+    case $plat in
+        i686|x86_64|intel|aarch64|s390x|ppc64le) ;;
+        *) echo Did not recognize plat $plat; return 1 ;;
+    esac
+    local uname=${2:-$(uname)}
+    if [ "$uname" != "Darwin" ]; then
+        if [ "$plat" == "intel" ]; then
+            echo plat=intel not allowed for Manylinux
+            return 1
+        fi
+        echo "manylinux${MB_ML_VER}_${plat}"
         return
     fi
     # macOS 32-bit arch is i386

--- a/gfortran_utils.sh
+++ b/gfortran_utils.sh
@@ -9,6 +9,9 @@ function get_distutils_platform {
     # Report platform as in form of distutils get_platform.
     # This is like the platform tag that pip will use.
     # Modify fat architecture tags on macOS to reflect compiled architecture
+
+    # Deprecate this function once get_distutils_platform_ex is used in all
+    # downstream projects
     local plat=$1
     case $plat in
         i686|x86_64|intel|aarch64|s390x|ppc64le) ;;
@@ -35,7 +38,7 @@ function get_distutils_platform_ex {
     # Modify fat architecture tags on macOS to reflect compiled architecture
     # For non-darwin, report manylinux version
     local plat=$1
-    local MB_ML_VER=${MB_ML_VER:-1}
+    local mb_ml_ver=${MB_ML_VER:-1}
     case $plat in
         i686|x86_64|intel|aarch64|s390x|ppc64le) ;;
         *) echo Did not recognize plat $plat; return 1 ;;
@@ -46,7 +49,7 @@ function get_distutils_platform_ex {
             echo plat=intel not allowed for Manylinux
             return 1
         fi
-        echo "manylinux${MB_ML_VER}_${plat}"
+        echo "manylinux${mb_ml_ver}_${plat}"
         return
     fi
     # macOS 32-bit arch is i386
@@ -74,7 +77,7 @@ function get_gf_lib_for_suf {
     local plat=${3:-$PLAT}
     local uname=${4:-$(uname)}
     if [ -z "$prefix" ]; then echo Prefix not defined; exit 1; fi
-    local plat_tag=$(get_distutils_platform $plat $uname)
+    local plat_tag=$(get_distutils_platform_ex $plat $uname)
     if [ -n "$suffix" ]; then suffix="-$suffix"; fi
     local fname="$prefix-${plat_tag}${suffix}.tar.gz"
     local out_fname="${ARCHIVE_SDIR}/$fname"

--- a/test_gf_utils.sh
+++ b/test_gf_utils.sh
@@ -1,5 +1,7 @@
 # Get gfortran utils
 source gfortran_utils.sh
+set -e
+
 
 uname=$(uname)
 FNAME_ROOT="openblas-v0.3.0"
@@ -55,3 +57,21 @@ rm $exp_64_tgz $exp_32_tgz
 [ "$(get_gf_lib "${FNAME_ROOT}" "i686")" == "$exp_32_tgz" ] || \
     (echo Wrong tgz output; exit 1)
 [ -f "$exp_32_tgz" ] || (echo Failed archive fetch; exit 1)
+
+# Test get_distutils_platform_ex processing of MB_ML_VER
+if [ $uname != Darwin ]; then
+    export MB_ML_VER=2010
+    ml_plat_root="manylinux2010"
+    ml_exp_64_tgz="${ARCH_ROOT}-${ml_plat_root}_x86_64${SUFP}.tar.gz"
+    val=$(get_gf_lib "${FNAME_ROOT}" "x86_64")
+    [ "${val}" == "$ml_exp_64_tgz" ] || \
+        (echo Wrong tgz output ${val}, ${ml_exp_64_tgz}; exit 1)
+fi
+
+# Test get_distutils_platform since it is no longer used internally
+[ "$(get_distutils_platform "x86_64" "x86_64")" == "manylinux1_x86_64" ] || \
+    (echo Wrong get_distutils_platform output for x86_64; exit 1)
+
+darwin_target=$(echo $MACOSX_DEPLOYMENT_TARGET | tr .- _)
+[ "$(get_distutils_platform "x86_64" "Darwin")" == "macosx_${darwin_target}_x86_64" ] || \
+    (echo Wrong get_distutils_platform output for Darwin; exit 1)


### PR DESCRIPTION
xref gh-2

Add more platforms to the original version of `get_distutils_platform`

Also add another function that is unique to this repo, which extends the original function for the manylinux version. In time, we should
- convert downstream users `MacPython/openblas-libs` and the various `MacPython/*-wheels` to the new function
- deprecate `get_distutils_platform` 